### PR TITLE
Update Form example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,16 @@ automatically:
 
 ```php
 /**
- * @Route("/product/new")
+ * @Route("/product/new", name="product_new")
  */
 public function newProduct(Request $request): Response
 {
     return $this->handleForm(
-        $this->createForm(ProductFormType::class),
+        $this->createForm(ProductFormType::class, null,
+        [
+            'action' => $this->generateUrl('product_new'),
+        ]
+        ),
         $request,
         function (FormInterface $form) {
             // save...


### PR DESCRIPTION
Without specifying the action, Turbo redirect the full page to /. 

name="product_new" is not necessary in this specific example, it however may help newcomer to understand they can have separate route for this action (even if not recommended by the Symfony Form docs).

Not sure if it is a bug in turbo or me doing wrong, adding this fixes it.