### PR TITLE
Fix ParseError in Form example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ public function newProduct(Request $request): Response
         // save...
 
         return $this->redirectToRoute('product_list');
-    );
+    };
 
     return $this->renderForm('product/new.html.twig', [
         'form' => $form,


### PR DESCRIPTION
Fix `ParseError: Unclosed '{' does not match ')'` error in "Form Response Code Changes" section of a README. 